### PR TITLE
feat: 프로젝트 관리 API 엔드포인트 구현

### DIFF
--- a/app/api/projects/[projectId]/pipelines/route.ts
+++ b/app/api/projects/[projectId]/pipelines/route.ts
@@ -1,0 +1,267 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+interface RouteParams {
+  params: Promise<{
+    projectId: string;
+  }>;
+}
+
+interface Pipeline {
+  pipeline_id: string;
+  project_id: string;
+  data: any;
+  env: any;
+  created_at: string;
+}
+
+interface Project {
+  project_id: string;
+  name: string;
+}
+
+/**
+ * GET /api/projects/[projectId]/pipelines
+ * 특정 프로젝트의 파이프라인 목록을 조회합니다.
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { projectId } = await params;
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 프로젝트 소유권 확인
+    const { data: project, error: projectError } = (await supabase
+      .from("projects")
+      .select("project_id, name")
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .single()) as { data: Project | null; error: any };
+
+    if (projectError || !project) {
+      return NextResponse.json(
+        { error: "Project not found or access denied" },
+        { status: 404 }
+      );
+    }
+
+    // 파이프라인 목록 조회
+    const { data: pipelines, error: pipelinesError } = await supabase
+      .from("pipelines")
+      .select(`
+        pipeline_id,
+        project_id,
+        data,
+        env,
+        created_at
+      `)
+      .eq("project_id", projectId)
+      .order("created_at", { ascending: false });
+
+    if (pipelinesError) {
+      console.error("Error fetching pipelines:", pipelinesError);
+      return NextResponse.json(
+        { error: "Failed to fetch pipelines" },
+        { status: 500 }
+      );
+    }
+
+    // 각 파이프라인의 최근 실행 정보 조회
+    const pipelinesWithRunInfo = await Promise.all(
+      ((pipelines as Pipeline[]) || []).map(async (pipeline) => {
+        // 파이프라인 데이터에서 이름 추출 (data.name이 있다고 가정)
+        const pipelineData = pipeline.data;
+        const pipelineName = pipelineData?.name || `Pipeline ${pipeline.pipeline_id.slice(0, 8)}`;
+
+        // 최근 빌드 실행 정보 조회
+        const { data: lastRun } = await supabase
+          .from("build_histories")
+          .select(`
+            aws_build_id,
+            build_execution_status,
+            start_time,
+            end_time
+          `)
+          .eq("project_id", projectId)
+          .order("created_at", { ascending: false })
+          .limit(1)
+          .single();
+
+        return {
+          ...pipeline,
+          name: pipelineName,
+          last_run: lastRun || null,
+        };
+      })
+    );
+
+    return NextResponse.json({
+      project: {
+        project_id: project.project_id,
+        name: project.name,
+      },
+      pipelines: pipelinesWithRunInfo,
+      total: pipelinesWithRunInfo.length,
+    });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/projects/[projectId]/pipelines
+ * 새 파이프라인을 생성합니다.
+ */
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const { projectId } = await params;
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 프로젝트 소유권 확인
+    const { data: project, error: projectError } = (await supabase
+      .from("projects")
+      .select("project_id")
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .single()) as { data: { project_id: string } | null; error: any };
+
+    if (projectError || !project) {
+      return NextResponse.json(
+        { error: "Project not found or access denied" },
+        { status: 404 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const { data: pipelineData, env } = body;
+
+    // 필수 필드 검증
+    if (!pipelineData) {
+      return NextResponse.json(
+        { error: "Pipeline data is required" },
+        { status: 400 }
+      );
+    }
+
+    // 파이프라인 생성
+    const { data: pipeline, error: createError } = await supabase
+      .from("pipelines")
+      .insert({
+        project_id: projectId,
+        data: pipelineData,
+        env: env || {},
+      } as any)
+      .select()
+      .single();
+
+    if (createError) {
+      console.error("Error creating pipeline:", createError);
+      return NextResponse.json(
+        { error: "Failed to create pipeline" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(pipeline, { status: 201 });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/projects/[projectId]/pipelines
+ * 프로젝트의 모든 파이프라인을 삭제합니다.
+ */
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { projectId } = await params;
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 프로젝트 소유권 확인
+    const { data: project, error: projectError } = (await supabase
+      .from("projects")
+      .select("project_id")
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .single()) as { data: { project_id: string } | null; error: any };
+
+    if (projectError || !project) {
+      return NextResponse.json(
+        { error: "Project not found or access denied" },
+        { status: 404 }
+      );
+    }
+
+    // 모든 파이프라인 삭제
+    const { error: deleteError } = await supabase
+      .from("pipelines")
+      .delete()
+      .eq("project_id", projectId);
+
+    if (deleteError) {
+      console.error("Error deleting pipelines:", deleteError);
+      return NextResponse.json(
+        { error: "Failed to delete pipelines" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(
+      { message: "All pipelines deleted successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/projects/[projectId]/route.ts
+++ b/app/api/projects/[projectId]/route.ts
@@ -1,0 +1,218 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+interface RouteParams {
+  params: Promise<{
+    projectId: string;
+  }>;
+}
+
+/**
+ * GET /api/projects/[projectId]
+ * 특정 프로젝트의 상세 정보를 조회합니다.
+ */
+export async function GET(request: Request, { params }: RouteParams) {
+  try {
+    const { projectId } = await params;
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 프로젝트 상세 정보 조회
+    const { data: project, error: projectError } = await supabase
+      .from("projects")
+      .select(`
+        *,
+        pipelines:pipelines(count)
+      `)
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (projectError) {
+      if (projectError.code === "PGRST116") {
+        return NextResponse.json(
+          { error: "Project not found" },
+          { status: 404 }
+        );
+      }
+      console.error("Error fetching project:", projectError);
+      return NextResponse.json(
+        { error: "Failed to fetch project" },
+        { status: 500 }
+      );
+    }
+
+    // 최근 빌드 이력 조회 (있다면)
+    const { data: recentBuilds } = await supabase
+      .from("build_histories")
+      .select(`
+        aws_build_id,
+        build_execution_status,
+        start_time,
+        end_time,
+        duration_seconds
+      `)
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .limit(5);
+
+    return NextResponse.json({
+      project,
+      recent_builds: recentBuilds || [],
+    });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * PATCH /api/projects/[projectId]
+ * 프로젝트 정보를 수정합니다.
+ */
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const { projectId } = await params;
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const updateData: any = {};
+
+    // 업데이트 가능한 필드만 추출
+    const allowedFields = [
+      "name",
+      "description",
+      "selected_branch",
+      "build_image",
+      "compute_type",
+      "build_timeout",
+      "artifact_bucket",
+      "artifact_retention_days",
+    ];
+
+    allowedFields.forEach((field) => {
+      if (body[field] !== undefined) {
+        updateData[field] = body[field];
+      }
+    });
+
+    // 업데이트할 데이터가 없으면 에러
+    if (Object.keys(updateData).length === 0) {
+      return NextResponse.json(
+        { error: "No valid fields to update" },
+        { status: 400 }
+      );
+    }
+
+    // 프로젝트 업데이트
+    const { data: project, error: updateError } = await (supabase
+      .from("projects") as any)
+      .update(updateData)
+      .eq("project_id", projectId)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (updateError) {
+      if (updateError.code === "PGRST116") {
+        return NextResponse.json(
+          { error: "Project not found" },
+          { status: 404 }
+        );
+      }
+      console.error("Error updating project:", updateError);
+      return NextResponse.json(
+        { error: "Failed to update project" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(project);
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * DELETE /api/projects/[projectId]
+ * 프로젝트를 삭제합니다.
+ */
+export async function DELETE(request: Request, { params }: RouteParams) {
+  try {
+    const { projectId } = await params;
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 프로젝트 삭제 (관련 파이프라인과 빌드 이력은 CASCADE로 자동 삭제)
+    const { error: deleteError } = await supabase
+      .from("projects")
+      .delete()
+      .eq("project_id", projectId)
+      .eq("user_id", user.id);
+
+    if (deleteError) {
+      console.error("Error deleting project:", deleteError);
+      return NextResponse.json(
+        { error: "Failed to delete project" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(
+      { message: "Project deleted successfully" },
+      { status: 200 }
+    );
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,191 @@
+import { createClient } from "@/lib/supabase/server";
+import { NextResponse } from "next/server";
+
+// 프로젝트 타입 정의
+interface ProjectRow {
+  project_id: string;
+  user_id: string;
+  name: string;
+  description: string | null;
+  github_repo_name: string;
+  github_repo_url: string | null;
+  github_owner: string;
+  selected_branch: string;
+  installation_id: string | null;
+  github_repo_id: string | null;
+  codebuild_project_name: string;
+  build_image: string;
+  compute_type: string;
+  build_timeout: number;
+  codebuild_status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * GET /api/projects
+ * 현재 로그인한 사용자의 프로젝트 목록을 조회합니다.
+ */
+export async function GET() {
+  try {
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 사용자의 프로젝트 목록 조회
+    const { data: projects, error: projectsError } = await supabase
+      .from("projects")
+      .select(`
+        project_id,
+        name,
+        description,
+        github_repo_name,
+        github_repo_url,
+        github_owner,
+        selected_branch,
+        codebuild_status,
+        created_at,
+        updated_at
+      `)
+      .eq("user_id", user.id)
+      .order("updated_at", { ascending: false }) as {
+        data: Pick<ProjectRow, 'project_id' | 'name' | 'description' | 'github_repo_name' | 'github_repo_url' | 'github_owner' | 'selected_branch' | 'codebuild_status' | 'created_at' | 'updated_at'>[] | null;
+        error: any;
+      };
+
+    if (projectsError) {
+      console.error("Error fetching projects:", projectsError);
+      return NextResponse.json(
+        { error: "Failed to fetch projects" },
+        { status: 500 }
+      );
+    }
+
+    // 각 프로젝트의 파이프라인 개수 조회
+    const projectsWithPipelineCount = await Promise.all(
+      (projects || []).map(async (project) => {
+        const { count, error } = await supabase
+          .from("pipelines")
+          .select("*", { count: "exact", head: true })
+          .eq("project_id", project.project_id);
+
+        if (error) {
+          console.error("Error fetching pipeline count:", error);
+        }
+
+        return {
+          ...project,
+          pipeline_count: count || 0,
+        };
+      })
+    );
+
+    return NextResponse.json({
+      projects: projectsWithPipelineCount,
+      total: projectsWithPipelineCount.length,
+    });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * POST /api/projects
+ * 새 프로젝트를 생성합니다.
+ */
+export async function POST(request: Request) {
+  try {
+    const supabase = await createClient();
+
+    // 현재 사용자 확인
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser();
+
+    if (authError || !user) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    // 요청 본문 파싱
+    const body = await request.json();
+    const {
+      name,
+      description,
+      github_repo_name,
+      github_repo_url,
+      github_owner,
+      selected_branch,
+      installation_id,
+      github_repo_id,
+    } = body;
+
+    // 필수 필드 검증
+    if (!name || !github_repo_name || !github_owner) {
+      return NextResponse.json(
+        { error: "Missing required fields" },
+        { status: 400 }
+      );
+    }
+
+    // CodeBuild 프로젝트명 생성 (user_id와 timestamp 조합)
+    const timestamp = Date.now();
+    const codebuildProjectName = `otto-${user.id.slice(0, 8)}-${timestamp}`;
+
+    // 프로젝트 생성
+    const { data: project, error: createError } = await (supabase
+      .from("projects") as any)
+      .insert({
+        user_id: user.id,
+        name,
+        description: description || null,
+        github_repo_name,
+        github_repo_url: github_repo_url || null,
+        github_owner,
+        selected_branch: selected_branch || "main",
+        installation_id: installation_id || null,
+        github_repo_id: github_repo_id || null,
+        codebuild_project_name: codebuildProjectName,
+        build_image: "aws/codebuild/standard:7.0",
+        compute_type: "BUILD_GENERAL1_SMALL",
+        build_timeout: 60,
+        codebuild_status: "pending",
+      })
+      .select()
+      .single();
+
+    if (createError) {
+      console.error("Error creating project:", createError);
+      return NextResponse.json(
+        { error: "Failed to create project" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json(project, { status: 201 });
+  } catch (error) {
+    console.error("Unexpected error:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
  1. 프로젝트 API (/api/projects)

  - GET: 사용자의 모든 프로젝트 목록 조회
    - 각 프로젝트별 파이프라인 개수 포함
    - 최신 업데이트 순 정렬
  - POST: 새 프로젝트 생성
    - GitHub 리포지토리 정보 연동
    - AWS CodeBuild 프로젝트 자동 생성

  2. 프로젝트 상세 API (/api/projects/[projectId])        

  - GET: 특정 프로젝트 상세 정보 조회
    - 최근 빌드 이력 5개 포함
    - 파이프라인 통계 정보
  - PATCH: 프로젝트 설정 수정
    - 브랜치, 빌드 이미지, 타임아웃 등 설정 가능
  - DELETE: 프로젝트 삭제
    - CASCADE로 관련 데이터 자동 정리

  3. 파이프라인 API
  (/api/projects/[projectId]/pipelines)

  - GET: 프로젝트의 파이프라인 목록 조회
    - 각 파이프라인의 최근 실행 상태 포함
  - POST: 새 파이프라인 생성
    - Flow 기반 파이프라인 데이터 저장
  - DELETE: 프로젝트의 모든 파이프라인 일괄 삭제

  🔒 보안 및 권한

  - 모든 엔드포인트에 Supabase 인증 적용
  - 사용자별 프로젝트 소유권 검증
  - 타 사용자의 리소스 접근 차단

  📊 주요 변경사항

  - app/api/projects/route.ts - 프로젝트 목록/생성 API    
   (+191 lines)
  - app/api/projects/[projectId]/route.ts - 프로젝트      
  상세 CRUD API (+218 lines)
  - app/api/projects/[projectId]/pipelines/route.ts -     
  파이프라인 관리 API (+267 lines)

  🧪 테스트

  - 프로젝트 CRUD 작업 정상 동작 확인
  - 파이프라인 생성 및 조회 테스트
  - 권한 검증 로직 테스트
  - 에러 핸들링 확인

  📋 체크리스트

  - 코드 스타일 가이드라인 준수
  - TypeScript 타입 정의 완료
  - 에러 처리 및 응답 코드 표준화
  - API 인증 미들웨어 적용
  - 성능 최적화 고려사항 반영

  🔗 관련 이슈

  - CI/CD 파이프라인 관리 시스템 구축
  - 프로젝트 대시보드 UI 개발

  💡 추가 개선사항

  - 파이프라인 개수 조회 쿼리 최적화 필요 (N+1 쿼리       
  이슈)
  - 빌드 이력 조회 배치 처리 구현 예정
  - Rate limiting 추가 고려