### PR TITLE
fix: Fix log field mapping between database and frontend display

### DIFF
--- a/components/logs/PipelineLogs/components/LogDetailModal.tsx
+++ b/components/logs/PipelineLogs/components/LogDetailModal.tsx
@@ -114,7 +114,7 @@ const LogDetailModal: React.FC<LogDetailModalProps> = ({
         {/* Log Viewer */}
         <div className="flex-1 overflow-hidden p-6">
           <UnifiedLogViewer
-            buildId={log.id}
+            buildId={log.awsBuildId || log.id} // awsBuildId가 있으면 사용, 없으면 id 사용
             autoRefresh={log.status === 'running'}
             refreshInterval={3000}
             className="h-full"

--- a/lib/api/pipeline-logs.ts
+++ b/lib/api/pipeline-logs.ts
@@ -6,6 +6,23 @@ import type { LogItem } from '@/types/logs';
 type BuildHistoryRow = Database['public']['Tables']['build_histories']['Row'];
 type ProjectRow = Database['public']['Tables']['projects']['Row'];
 
+// 조인된 데이터 타입
+export type BuildHistoryWithJoins = BuildHistoryRow & {
+  projects?: {
+    name: string;
+    github_repo_name: string | null;
+    selected_branch: string | null;
+    github_owner: string;
+  };
+  push_event?: {
+    commit_sha: string;
+    commit_message: string | null;
+    commit_author_name: string | null;
+    branch_name: string | null;
+    pushed_at: string;
+  } | null;
+};
+
 /**
  * Pipeline Logs API Functions
  * Supabase에서 실제 빌드 기록 데이터를 조회하는 함수들
@@ -132,7 +149,7 @@ export async function getAllUserBuildHistories(
     status?: string;
     projectId?: string;
   } = {}
-): Promise<{ builds: BuildHistoryRow[]; hasMore: boolean; totalCount: number }> {
+): Promise<{ builds: BuildHistoryWithJoins[]; hasMore: boolean; totalCount: number }> {
   const supabase = createClient();
   const { limit = 20, offset = 0, status, projectId } = options;
 
@@ -157,7 +174,7 @@ export async function getAllUserBuildHistories(
 
   const projectIds = projects.map(p => p.project_id);
 
-  // 빌드 기록 조회
+  // 빌드 기록 조회 - push_events도 함께 조회
   let query = supabase
     .from('build_histories')
     .select('*', { count: 'exact' })
@@ -173,31 +190,49 @@ export async function getAllUserBuildHistories(
     query = query.eq('project_id', projectId);
   }
 
-  const { data, error, count } = await query;
+  const { data: builds, error, count } = await query;
 
   if (error) {
     console.error('Error fetching all build histories:', error);
     throw new Error(`Failed to fetch build histories: ${error.message}`);
   }
 
-  const hasMore = count ? offset + limit < count : false;
-
-  // 빌드 데이터에 해당 프로젝트 정보 추가
-  const buildsWithProject = (data || []).map((build: BuildHistoryRow) => {
+  // 각 빌드에 대한 push_event 조회
+  // build_histories의 created_at 기준으로 가장 가까운 이전 push_event를 찾음
+  const buildsWithJoins: BuildHistoryWithJoins[] = [];
+  
+  for (const build of (builds as BuildHistoryRow[] || [])) {
+    // 해당 프로젝트의 정보 찾기
     const project = projects?.find((p) => p.project_id === build.project_id);
-    return {
+    
+    // 해당 빌드와 연관된 push_event 찾기
+    // 빌드의 created_at 이전의 가장 최근 push_event를 찾음
+    const { data: pushEvents } = await supabase
+      .from('push_events')
+      .select('commit_sha, commit_message, commit_author_name, branch_name, pushed_at')
+      .eq('project_id', build.project_id)
+      .lte('pushed_at', build.created_at || new Date().toISOString())
+      .order('pushed_at', { ascending: false })
+      .limit(1);
+    
+    const pushEvent = pushEvents && pushEvents.length > 0 ? pushEvents[0] : null;
+    
+    buildsWithJoins.push({
       ...build,
       projects: project ? {
         name: project.name,
         github_repo_name: project.github_repo_name,
         selected_branch: project.selected_branch,
         github_owner: project.github_owner
-      } : undefined
-    };
-  });
+      } : undefined,
+      push_event: pushEvent || null
+    });
+  }
+
+  const hasMore = count ? offset + limit < count : false;
 
   return {
-    builds: buildsWithProject,
+    builds: buildsWithJoins,
     hasMore,
     totalCount: count || 0
   };
@@ -207,31 +242,41 @@ export async function getAllUserBuildHistories(
  * Supabase 빌드 데이터를 LogItem 형태로 변환
  */
 export function transformBuildToLogItem(
-  build: BuildHistoryRow & {
-    projects?: {
-      name: string;
-      github_repo_name: string;
-      selected_branch: string | null;
-      github_owner?: string;
-    };
-  }
+  build: BuildHistoryWithJoins
 ): LogItem {
-  // 빌드 상태 매핑
+  // 빌드 상태 매핑 - 대문자/소문자 모두 처리
   const statusMap: Record<string, LogItem['status']> = {
+    // 대문자 (NestJS API 응답)
     'SUCCEEDED': 'success',
+    'SUCCESS': 'success',
     'FAILED': 'failed',
     'IN_PROGRESS': 'running',
+    'RUNNING': 'running',
     'STOPPED': 'failed',
     'FAULT': 'failed',
     'TIMED_OUT': 'failed',
     'PENDING': 'pending',
+    // 소문자 (DB 직접 조회)
+    'succeeded': 'success',
     'success': 'success',
     'failed': 'failed',
+    'in_progress': 'running',
     'running': 'running',
+    'stopped': 'failed',
+    'timed_out': 'failed',
     'pending': 'pending'
   };
 
-  const status = statusMap[build.build_execution_status] || 'pending';
+  // 디버깅: 실제 상태 값 확인
+  if (!build.build_execution_status) {
+    console.warn(`Build status is null/undefined for build ${build.id}`);
+  } else if (!statusMap[build.build_execution_status]) {
+    console.warn(`Unknown build status: "${build.build_execution_status}" for build ${build.id}`);
+  }
+  
+  const status = build.build_execution_status 
+    ? statusMap[build.build_execution_status] || 'pending'
+    : 'pending';
 
   // 실행 시간 계산
   const getDuration = () => {
@@ -272,20 +317,26 @@ export function transformBuildToLogItem(
     return `${days}d ago`;
   };
 
+  // push_event 데이터가 있으면 실제 커밋 정보 사용, 없으면 기본값 사용
+  const pushEvent = build.push_event;
+  
   return {
     id: build.id,
+    awsBuildId: build.aws_build_id, // AWS CodeBuild ID 추가
     status,
     pipelineName: build.projects?.name || 'Unknown Project',
     trigger: {
-      type: 'Push to ' + (build.projects?.selected_branch || 'main'),
-      author: build.projects?.github_owner || 'system',
+      type: pushEvent?.branch_name 
+        ? `Push to ${pushEvent.branch_name}`
+        : `Push to ${build.projects?.selected_branch || 'main'}`,
+      author: pushEvent?.commit_author_name || build.projects?.github_owner || 'system',
       time: getTimeAgo(build.created_at)
     },
-    branch: build.projects?.selected_branch || 'main',
+    branch: pushEvent?.branch_name || build.projects?.selected_branch || 'main',
     commit: {
-      message: 'Build triggered', // 실제로는 push_events에서 가져와야 함
-      sha: build.aws_build_id.substring(0, 7), // AWS Build ID 일부 사용
-      author: build.projects?.github_owner || 'Unknown'
+      message: pushEvent?.commit_message || 'Build triggered',
+      sha: pushEvent?.commit_sha?.substring(0, 7) || build.aws_build_id.substring(0, 7),
+      author: pushEvent?.commit_author_name || build.projects?.github_owner || 'Unknown'
     },
     duration: getDuration(),
     isNew: false // 새로운 로그 여부는 클라이언트에서 관리

--- a/types/logs.ts
+++ b/types/logs.ts
@@ -116,6 +116,7 @@ export interface LogLine {
 
 export interface LogItem {
   id: string;
+  awsBuildId?: string; // AWS CodeBuild ID for log retrieval
   status: "success" | "failed" | "running" | "pending";
   pipelineName: string;
   trigger: {


### PR DESCRIPTION
## 문제점
  - DB의 실제 커밋 정보가 표시되지 않고 하드코딩된 값 사용
  - build_execution_status 대소문자 불일치로 상태가 PENDING으로 표시
  - 로그 상세 모달에서 AWS Build ID 대신 UUID 사용으로 로그 조회 실패

## 해결 
#### push_events 테이블 조인으로 실제 커밋 정보 표시
 - 커밋 SHA, 메시지, 작성자 정보를 push_events에서 가져옴
 - 빈 결과 처리 로직 추가 (에러 방지)

#### 상태 매핑 개선
 - 대문자/소문자 모든 케이스 처리 (SUCCESS/success, RUNNING/running 등)
 - null/undefined 상태 안전 처리
 - 디버깅 로그 추가

#### 로그 상세 조회 수정
 - LogItem 타입에 awsBuildId 필드 추가
 - UnifiedLogViewer에 aws_build_id 전달로 실제 로그 조회 가능

## 영향
  - 로그 목록에서 실제 커밋 정보 확인 가능
  - 빌드 상태가 올바르게 표시

## 스크린샷
<img width="1870" height="1049" alt="image" src="https://github.com/user-attachments/assets/ff3b5b75-ca0a-4c00-b2c7-130703cc9fba" />

<img width="1887" height="1041" alt="image" src="https://github.com/user-attachments/assets/2af0d1de-33a5-42a0-94f7-c3a0fe63b642" />
